### PR TITLE
Add agent gallery page with gradient card component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import Index from './pages/Index'
+import AgentGallery from './pages/AgentGallery'
 import NotFound from './pages/NotFound'
 import { Toaster } from '@/components/ui/sonner'
 
@@ -13,6 +14,7 @@ function App() {
       <Router>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/agents" element={<AgentGallery />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
         <Toaster />

--- a/src/components/ui/demo.tsx
+++ b/src/components/ui/demo.tsx
@@ -1,11 +1,6 @@
-import { SignInPage } from "@/components/ui/sign-in-flow-1";
+import { GradientCard } from "@/components/ui/gradient-card"
 
-const DemoOne = () => {
-  return (
-    <div className="flex w-full h-screen justify-center items-center">
-      <SignInPage />
-    </div>
-  );
-};
-
-export { DemoOne };
+export const Demo = () => {
+  return <GradientCard />
+}
+export default Demo

--- a/src/components/ui/gradient-card.tsx
+++ b/src/components/ui/gradient-card.tsx
@@ -1,0 +1,320 @@
+'use client'
+import React, { useRef, useState } from "react"
+import { motion } from "framer-motion"
+
+export interface GradientCardProps {
+  title?: string
+  description?: string
+}
+
+export const GradientCard: React.FC<GradientCardProps> = ({
+  title = "AI-Powered Inbox Sorting",
+  description = "OpenMail revolutionizes email management with AI-driven sorting, boosting productivity and accessibility",
+}) => {
+  const cardRef = useRef<HTMLDivElement>(null)
+  const [isHovered, setIsHovered] = useState(false)
+  const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 })
+  const [rotation, setRotation] = useState({ x: 0, y: 0 })
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (cardRef.current) {
+      const rect = cardRef.current.getBoundingClientRect()
+      const x = e.clientX - rect.left - rect.width / 2
+      const y = e.clientY - rect.top - rect.height / 2
+      setMousePosition({ x, y })
+      const rotateX = -(y / rect.height) * 5
+      const rotateY = (x / rect.width) * 5
+      setRotation({ x: rotateX, y: rotateY })
+    }
+  }
+
+  const handleMouseLeave = () => {
+    setIsHovered(false)
+    setRotation({ x: 0, y: 0 })
+  }
+
+  return (
+    <div className="w-full h-screen flex items-center justify-center bg-black">
+      <motion.div
+        ref={cardRef}
+        className="relative rounded-[32px] overflow-hidden"
+        style={{
+          width: '360px',
+          height: '450px',
+          transformStyle: 'preserve-3d',
+          backgroundColor: '#0e131f',
+          boxShadow: '0 -10px 100px 10px rgba(78, 99, 255, 0.25), 0 0 10px 0 rgba(0, 0, 0, 0.5)'
+        }}
+        initial={{ y: 0 }}
+        animate={{
+          y: isHovered ? -5 : 0,
+          rotateX: rotation.x,
+          rotateY: rotation.y,
+          perspective: 1000
+        }}
+        transition={{
+          type: 'spring',
+          stiffness: 300,
+          damping: 20
+        }}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={handleMouseLeave}
+        onMouseMove={handleMouseMove}
+      >
+        <motion.div
+          className="absolute inset-0 z-35 pointer-events-none"
+          style={{
+            background:
+              'linear-gradient(135deg, rgba(255,255,255,0.08) 0%, rgba(255,255,255,0) 40%, rgba(255,255,255,0) 80%, rgba(255,255,255,0.05) 100%)',
+            backdropFilter: 'blur(2px)'
+          }}
+          animate={{
+            opacity: isHovered ? 0.7 : 0.5,
+            rotateX: -rotation.x * 0.2,
+            rotateY: -rotation.y * 0.2,
+            z: 1
+          }}
+          transition={{ duration: 0.4, ease: 'easeOut' }}
+        />
+
+        <motion.div
+          className="absolute inset-0 z-0"
+          style={{ background: 'linear-gradient(180deg, #000000 0%, #000000 70%)' }}
+          animate={{ z: -1 }}
+        />
+
+        <motion.div
+          className="absolute inset-0 opacity-30 mix-blend-overlay z-10"
+          style={{
+            backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='5' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E")`
+          }}
+          animate={{ z: -0.5 }}
+        />
+
+        <motion.div
+          className="absolute inset-0 opacity-10 mix-blend-soft-light z-11 pointer-events-none"
+          style={{
+            backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 400 400' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='smudge'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.01' numOctaves='3' seed='5' stitchTiles='stitch'/%3E%3CfeGaussianBlur stdDeviation='10'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23smudge)'/%3E%3C/svg%3E")`,
+            backdropFilter: 'blur(1px)'
+          }}
+          animate={{ z: -0.25 }}
+        />
+
+        <motion.div
+          className="absolute bottom-0 left-0 right-0 h-2/3 z-20"
+          style={{
+            background: `
+              radial-gradient(ellipse at bottom right, rgba(172, 92, 255, 0.7) -10%, rgba(79, 70, 229, 0) 70%),
+              radial-gradient(ellipse at bottom left, rgba(56, 189, 248, 0.7) -10%, rgba(79, 70, 229, 0) 70%)
+            `,
+            filter: 'blur(40px)'
+          }}
+          animate={{ opacity: isHovered ? 0.9 : 0.8, y: isHovered ? rotation.x * 0.5 : 0, z: 0 }}
+          transition={{ duration: 0.4, ease: 'easeOut' }}
+        />
+
+        <motion.div
+          className="absolute bottom-0 left-0 right-0 h-2/3 z-21"
+          style={{
+            background: `
+              radial-gradient(circle at bottom center, rgba(161, 58, 229, 0.7) -20%, rgba(79, 70, 229, 0) 60%)
+            `,
+            filter: 'blur(45px)'
+          }}
+          animate={{
+            opacity: isHovered ? 0.85 : 0.75,
+            y: isHovered ? `calc(10% + ${rotation.x * 0.3}px)` : '10%',
+            z: 0
+          }}
+          transition={{ duration: 0.4, ease: 'easeOut' }}
+        />
+
+        <motion.div
+          className="absolute bottom-0 left-0 right-0 h-[2px] z-25"
+          style={{
+            background:
+              'linear-gradient(90deg, rgba(255, 255, 255, 0.05) 0%, rgba(255, 255, 255, 0.7) 50%, rgba(255, 255, 255, 0.05) 100%)'
+          }}
+          animate={{
+            boxShadow: isHovered
+              ? '0 0 20px 4px rgba(172, 92, 255, 0.9), 0 0 30px 6px rgba(138, 58, 185, 0.7), 0 0 40px 8px rgba(56, 189, 248, 0.5)'
+              : '0 0 15px 3px rgba(172, 92, 255, 0.8), 0 0 25px 5px rgba(138, 58, 185, 0.6), 0 0 35px 7px rgba(56, 189, 248, 0.4)',
+            opacity: isHovered ? 1 : 0.9,
+            z: 0.5
+          }}
+          transition={{ duration: 0.4, ease: 'easeOut' }}
+        />
+        <motion.div
+          className="absolute bottom-0 left-0 h-1/4 w-[1px] z-25 rounded-full"
+          style={{
+            background:
+              'linear-gradient(to top, rgba(255, 255, 255, 0.7) 0%, rgba(255, 255, 255, 0.5) 20%, rgba(255, 255, 255, 0.3) 40%, rgba(255, 255, 255, 0.1) 60%, rgba(255, 255, 255, 0) 80%)'
+          }}
+          animate={{
+            boxShadow: isHovered
+              ? '0 0 20px 4px rgba(172, 92, 255, 0.9), 0 0 30px 6px rgba(138, 58, 185, 0.7), 0 0 40px 8px rgba(56, 189, 248, 0.5)'
+              : '0 0 15px 3px rgba(172, 92, 255, 0.8), 0 0 25px 5px rgba(138, 58, 185, 0.6), 0 0 35px 7px rgba(56, 189, 248, 0.4)',
+            opacity: isHovered ? 1 : 0.9,
+            z: 0.5
+          }}
+          transition={{ duration: 0.4, ease: 'easeOut' }}
+        />
+        <motion.div
+          className="absolute bottom-0 left-0 h-1/4 z-25"
+          style={{
+            background:
+              'linear-gradient(to top, rgba(255, 255, 255, 0.7) 0%, rgba(255, 255, 255, 0.55) 15%, rgba(255, 255, 255, 0.4) 30%, rgba(255, 255, 255, 0.25) 45%, rgba(255, 255, 255, 0.1) 70%, rgba(255, 255, 255, 0) 85%)'
+          }}
+          animate={{
+            boxShadow: isHovered
+              ? '0 0 20px 4px rgba(172, 92, 255, 0.9), 0 0 30px 6px rgba(138, 58, 185, 0.7), 0 0 40px 8px rgba(56, 189, 248, 0.5)'
+              : '0 0 15px 3px rgba(172, 92, 255, 0.8), 0 0 25px 5px rgba(138, 58, 185, 0.6), 0 0 35px 7px rgba(56, 189, 248, 0.4)',
+            opacity: isHovered ? 1 : 0.9,
+            z: 0.5
+          }}
+          transition={{ duration: 0.4, ease: 'easeOut' }}
+        />
+        <motion.div
+          className="absolute bottom-0 right-0 h-1/4 w-[1px] z-25 rounded-full"
+          style={{
+            background:
+              'linear-gradient(to top, rgba(255, 255, 255, 0.7) 0%, rgba(255, 255, 255, 0.5) 20%, rgba(255, 255, 255, 0.3) 40%, rgba(255, 255, 255, 0.1) 60%, rgba(255, 255, 255, 0) 80%)'
+          }}
+          animate={{
+            boxShadow: isHovered
+              ? '0 0 20px 4px rgba(172, 92, 255, 0.9), 0 0 30px 6px rgba(138, 58, 185, 0.7), 0 0 40px 8px rgba(56, 189, 248, 0.5)'
+              : '0 0 15px 3px rgba(172, 92, 255, 0.8), 0 0 25px 5px rgba(138, 58, 185, 0.6), 0 0 35px 7px rgba(56, 189, 248, 0.4)',
+            opacity: isHovered ? 1 : 0.9,
+            z: 0.5
+          }}
+          transition={{ duration: 0.4, ease: 'easeOut' }}
+        />
+        <motion.div
+          className="absolute bottom-0 right-0 h-1/3 z-25"
+          style={{
+            background:
+              'linear-gradient(to top, rgba(255, 255, 255, 0.7) 0%, rgba(255, 255, 255, 0.55) 15%, rgba(255, 255, 255, 0.4) 30%, rgba(255, 255, 255, 0.25) 45%, rgba(255, 255, 255, 0.1) 70%, rgba(255, 255, 255, 0) 85%)'
+          }}
+          animate={{
+            boxShadow: isHovered
+              ? '0 0 20px 4px rgba(172, 92, 255, 0.9), 0 0 30px 6px rgba(138, 58, 185, 0.7), 0 0 40px 8px rgba(56, 189, 248, 0.5)'
+              : '0 0 15px 3px rgba(172, 92, 255, 0.8), 0 0 25px 5px rgba(138, 58, 185, 0.6), 0 0 35px 7px rgba(56, 189, 248, 0.4)',
+            opacity: isHovered ? 1 : 0.9,
+            z: 0.5
+          }}
+          transition={{ duration: 0.4, ease: 'easeOut' }}
+        />
+
+        <motion.div className="relative flex flex-col h-full p-8 z-40" animate={{ z: 2 }}>
+          <motion.div
+            className="w-12 h-12 rounded-full flex items-center justify-center mb-6"
+            style={{
+              background: 'linear-gradient(225deg, #171c2c 0%, #121624 100%)',
+              position: 'relative',
+              overflow: 'hidden'
+            }}
+            initial={{ filter: 'blur(3px)', opacity: 0.7 }}
+            animate={{
+              filter: 'blur(0px)',
+              opacity: 1,
+              boxShadow: isHovered
+                ? '0 8px 16px -2px rgba(0, 0, 0, 0.3), 0 4px 8px -1px rgba(0, 0, 0, 0.2), inset 2px 2px 5px rgba(255, 255, 255, 0.15), inset -2px -2px 5px rgba(0, 0, 0, 0.7)'
+                : '0 6px 12px -2px rgba(0, 0, 0, 0.25), 0 3px 6px -1px rgba(0, 0, 0, 0.15), inset 1px 1px 3px rgba(255, 255, 255, 0.12), inset -2px -2px 4px rgba(0, 0, 0, 0.5)',
+              z: isHovered ? 10 : 5,
+              y: isHovered ? -2 : 0,
+              rotateX: isHovered ? -rotation.x * 0.5 : 0,
+              rotateY: isHovered ? -rotation.y * 0.5 : 0
+            }}
+            transition={{ duration: 0.4, ease: 'easeOut' }}
+          >
+            <div
+              className="absolute top-0 left-0 w-2/3 h-2/3 opacity-40"
+              style={{
+                background: 'radial-gradient(circle at top left, rgba(255, 255, 255, 0.5), transparent 80%)',
+                pointerEvents: 'none',
+                filter: 'blur(10px)'
+              }}
+            />
+            <div
+              className="absolute bottom-0 left-0 w-full h-1/2 opacity-50"
+              style={{
+                background: 'linear-gradient(to top, rgba(0, 0, 0, 0.4), transparent)',
+                pointerEvents: 'none',
+                backdropFilter: 'blur(3px)'
+              }}
+            />
+            <div className="flex items-center justify-center w-full h-full relative z-10">
+              <svg width="20" height="20" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M8 0L9.4 5.4L14.8 5.4L10.6 8.8L12 14.2L8 10.8L4 14.2L5.4 8.8L1.2 5.4L6.6 5.4L8 0Z" fill="white" />
+              </svg>
+            </div>
+          </motion.div>
+
+          <motion.div
+            className="mb-auto"
+            animate={{
+              z: isHovered ? 5 : 2,
+              rotateX: isHovered ? -rotation.x * 0.3 : 0,
+              rotateY: isHovered ? -rotation.y * 0.3 : 0
+            }}
+            transition={{ duration: 0.4, ease: 'easeOut' }}
+          >
+            <motion.h3
+              className="text-2xl font-medium text-white mb-3"
+              style={{ letterSpacing: '-0.01em', lineHeight: 1.2 }}
+              initial={{ filter: 'blur(3px)', opacity: 0.7 }}
+              animate={{
+                textShadow: isHovered ? '0 2px 4px rgba(0,0,0,0.2)' : 'none',
+                filter: 'blur(0px)',
+                opacity: 1,
+                transition: { duration: 1.2, delay: 0.2 }
+              }}
+            >
+              {title}
+            </motion.h3>
+
+            <motion.p
+              className="text-sm mb-6 text-gray-300"
+              style={{ lineHeight: 1.5, fontWeight: 350 }}
+              initial={{ filter: 'blur(3px)', opacity: 0.7 }}
+              animate={{
+                textShadow: isHovered ? '0 1px 2px rgba(0,0,0,0.1)' : 'none',
+                filter: 'blur(0px)',
+                opacity: 0.85,
+                transition: { duration: 1.2, delay: 0.4 }
+              }}
+            >
+              {description}
+            </motion.p>
+
+            <motion.a
+              href="#"
+              className="inline-flex items-center text-white text-sm font-medium group"
+              initial={{ filter: 'blur(3px)', opacity: 0.7 }}
+              animate={{
+                filter: 'blur(0px)',
+                opacity: 0.9,
+                transition: { duration: 1.2, delay: 0.6 }
+              }}
+              whileHover={{ filter: 'drop-shadow(0 0 5px rgba(255, 255, 255, 0.5))' }}
+            >
+              Learn More
+              <motion.svg
+                className="ml-1 w-4 h-4"
+                width="8"
+                height="8"
+                viewBox="0 0 16 16"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                animate={{ x: isHovered ? 4 : 0 }}
+                transition={{ duration: 0.6, ease: 'easeOut' }}
+              >
+                <path d="M1 8H15M15 8L8 1M15 8L8 15" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              </motion.svg>
+            </motion.a>
+          </motion.div>
+        </motion.div>
+      </motion.div>
+    </div>
+  )
+}

--- a/src/pages/AgentGallery.tsx
+++ b/src/pages/AgentGallery.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { GradientCard } from '@/components/ui/gradient-card'
+import { Card } from '@/components/ui/card'
+import { Sparkles } from 'lucide-react'
+
+interface Agent {
+  id: string
+  name: string
+  description: string
+  created_at: string
+  status: string
+}
+
+const fetchAgents = async (): Promise<Agent[]> => {
+  const response = await fetch('/api/agents')
+  if (!response.ok) {
+    throw new Error('Failed to fetch agents')
+  }
+  return response.json()
+}
+
+const AgentGallery = () => {
+  const { data: agents, isLoading, error } = useQuery({
+    queryKey: ['agents'],
+    queryFn: fetchAgents,
+  })
+
+  const mockAgents: Agent[] = [
+    {
+      id: '1',
+      name: 'Email Assistant',
+      description: 'Helps with email composition and replies',
+      created_at: new Date().toISOString(),
+      status: 'active',
+    },
+    {
+      id: '2',
+      name: 'Data Analyzer',
+      description: 'Analyzes and visualizes data patterns',
+      created_at: new Date(Date.now() - 86400000).toISOString(),
+      status: 'active',
+    },
+    {
+      id: '3',
+      name: 'Content Writer',
+      description: 'Creates engaging content and articles',
+      created_at: new Date(Date.now() - 172800000).toISOString(),
+      status: 'active',
+    },
+  ]
+
+  const displayAgents = error || !agents ? mockAgents : agents
+
+  return (
+    <div className="min-h-screen bg-background pt-20">
+      <h2 className="text-center text-2xl font-semibold mb-8 text-foreground">Agent Gallery</h2>
+      {isLoading ? (
+        <div className="flex justify-center">
+          <Card className="p-6 flex items-center space-x-2">
+            <div className="w-4 h-4 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+            <span className="text-muted-foreground">Loading agents...</span>
+          </Card>
+        </div>
+      ) : (
+        <div className="grid gap-8 grid-cols-1 md:grid-cols-2 lg:grid-cols-3 px-4 max-w-6xl mx-auto">
+          {displayAgents.map((agent) => (
+            <GradientCard key={agent.id} title={agent.name} description={agent.description} />
+          ))}
+        </div>
+      )}
+      {error && (
+        <p className="text-center text-sm text-muted-foreground mt-4">
+          Showing demo agents due to fetch error
+        </p>
+      )}
+    </div>
+  )
+}
+
+export default AgentGallery

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource react */
 import React, { useState, useEffect, useRef } from 'react'
+import { Link } from 'react-router-dom'
 import { HeroSection } from '@/components/ui/hero-section-dark'
 import { AnimatedAIChat } from '@/components/ui/animated-ai-chat'
 import { SignInModal } from '@/components/ui/sign-in-flow-adapted'
@@ -169,6 +170,7 @@ const Index = () => {
                 <a href="#" className="text-muted-foreground hover:text-foreground transition-colors">How it works</a>
                 <a href="#" className="text-muted-foreground hover:text-foreground transition-colors">Examples</a>
                 <a href="#" className="text-muted-foreground hover:text-foreground transition-colors">Pricing</a>
+                <Link to="/agents" className="text-muted-foreground hover:text-foreground transition-colors">Agent Gallery</Link>
               </>
             )}
             {isLoggedIn ? (


### PR DESCRIPTION
## Summary
- integrate reusable `GradientCard` component for demos
- add `AgentGallery` page showing all agents
- link to the new page from the navigation
- register gallery route in `App`
- update demo component to use `GradientCard`
- install `framer-motion`

## Testing
- `npm run lint` *(fails: several lint errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_6845c7fa8bd8832082518130dcbaf797